### PR TITLE
Allow `mtl-2.3` in `gi-cairo-connector`

### DIFF
--- a/gi-cairo-connector/gi-cairo-connector.cabal
+++ b/gi-cairo-connector/gi-cairo-connector.cabal
@@ -23,7 +23,7 @@ Source-Repository head
   subdir:       gi-cairo-connector
 
 Library
-        build-depends:    base >= 4 && < 5, mtl >= 2.2 && <2.3,
+        build-depends:    base >= 4 && < 5, mtl >= 2.2 && <2.4,
                           haskell-gi-base >=0.24.0 && <0.25,
                           gi-cairo >= 1.0 && <2,
                           gi-cairo-render == 0.1.*


### PR DESCRIPTION
Tested with `--allow-newer`, seems to work fine.